### PR TITLE
Added {-y} placeholder support

### DIFF
--- a/lib/tilelive-tms.js
+++ b/lib/tilelive-tms.js
@@ -7,8 +7,8 @@ module.exports = TmsSource;
 function TmsSource(uri, callback) {
     this.uri = uri.host + ":" + uri.pathname;
 
-    if (!(this.uri.match(/\{z}/) && this.uri.match(/\{x}/) && this.uri.match(/\{y}/))) {
-        callback(new Error("TMS URL template must contain {z}, {x} and {y} placeholders."));
+    if (!(this.uri.match(/\{z}/) && this.uri.match(/\{x}/) && (this.uri.match(/\{y}/) || this.uri.match(/\{-y}/)))) {
+        callback(new Error("TMS URL template must contain {z}, {x} and {y} (or {-y}) placeholders."));
         return;
     }
 
@@ -21,7 +21,11 @@ TmsSource.registerProtocols = function(tilelive) {
 
 TmsSource.prototype.getTile = function(z, x, y, callback) {
     request.get({
-        uri: this.uri.replace(/\{z}/i, z).replace(/\{x}/i, x).replace(/\{y}/i, String(Math.pow(2, z) - y - 1)),
+        uri: this.uri
+            .replace(/\{z}/i, z)
+            .replace(/\{x}/i, x)
+            .replace(/\{y}/i, String(Math.pow(2, z) - y - 1))
+            .replace(/\{-y}/i, y),
         encoding: null,
         timeout: 30e3 // 30 seconds
     }, function (error, response, body) {


### PR DESCRIPTION
This PR addresses well-known problem in difference between TMS and XYZ (Google) tiles coordinates via adaptation of OpenLayers method: https://openlayers.org/en/latest/apidoc/ol.source.XYZ.html -- where `{y}` placeholder calculated as `Math.pow(2, z) - y - 1`, and `{-y}` as `y` without any recalculations.